### PR TITLE
Added option to avoid animation on render

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Wrap the templates or template parts with the {{#Animate}}..{{/Animate}} helper 
 		</div>
 	{{/AnimateWithVelocity}}
 
+Animation is triggered on render by default, if you want to disable it add:
+
+    data-animate-on-render : 'false'
+
+to your data-animate element.
+
 ## Attributes and defaults
 	data-property: 'opacity',
 	data-duration: 200, // milliseconds
@@ -37,6 +43,7 @@ Wrap the templates or template parts with the {{#Animate}}..{{/Animate}} helper 
 	data-to-value: 1,
 	data-easing-in: 'linear',
 	data-easing-out: 'linear'
+	data-animate-on-render : 'true'
 
 For properties to animate look at the velocity documentation at http://julian.com/research/velocity/
 

--- a/animation-helper-velocity.js
+++ b/animation-helper-velocity.js
@@ -32,7 +32,10 @@ Template['AnimateWithVelocity'].rendered = function(){
         }
     });
 
-    this._animation_helper_parentNode._uihooks = {
+    // add the parentNode te the instance, so we can access it in the destroyed function
+    var parentNode = this.firstNode.parentNode;
+
+    parentNode._uihooks = {
         insertElement: function (node, next) {
 
             var $node = $(node);

--- a/animation-helper-velocity.js
+++ b/animation-helper-velocity.js
@@ -87,10 +87,7 @@ The destroyed method, which remove the hooks to make sure, they work again next 
 
 */
 Template['AnimateWithVelocity'].destroyed = function(){
-    var template = this;
-    Meteor.defer(function(){
-        template._animation_helper_parentNode._uihooks = null;
-    });
+    this._animation_helper_parentNode._uihooks = null;
 };
 
 

--- a/animation-helper-velocity.js
+++ b/animation-helper-velocity.js
@@ -16,9 +16,11 @@ Template['AnimateWithVelocity'].rendered = function(){
     // HACK: initial animation rendered, as insertElement, doesn't seem to fire
     _.each(this.findAll('*[data-animate]'), function(item){
         var $item = $(item);
-
-        // prevent when the insertElement hook already animated
-        if(!$item.hasClass('animating')) {
+        
+        
+        // prevent when the insertElement hook already animated and avoid animation on rendering if animate-on-render option is false
+        var animateOnRender = $item.data('animate-on-render') === false ? false : true;
+        if(!$item.hasClass('animating') && animateOnRender) {
             var animationProperty = generateAnimationProperties(item);
             $item.velocity(animationProperty.from, {duration: 0}).velocity(animationProperty.to, {
                 duration: $item.data('duration') || defaultDuration,

--- a/animation-helper-velocity.js
+++ b/animation-helper-velocity.js
@@ -82,13 +82,6 @@ Template['AnimateWithVelocity'].rendered = function(){
     };
 };
 
-/**
-The destroyed method, which remove the hooks to make sure, they work again next time.
-
-*/
-Template['AnimateWithVelocity'].destroyed = function(){
-    this._animation_helper_parentNode._uihooks = null;
-};
 
 
 // METHODS

--- a/animation-helper-velocity.js
+++ b/animation-helper-velocity.js
@@ -33,9 +33,9 @@ Template['AnimateWithVelocity'].rendered = function(){
     });
 
     // add the parentNode te the instance, so we can access it in the destroyed function
-    var parentNode = this.firstNode.parentNode;
+    this._animation_helper_parentNode = this.firstNode.parentNode;
 
-    parentNode._uihooks = {
+    this._animation_helper_parentNode._uihooks = {
         insertElement: function (node, next) {
 
             var $node = $(node);
@@ -82,6 +82,16 @@ Template['AnimateWithVelocity'].rendered = function(){
     };
 };
 
+/**
+The destroyed method, which remove the hooks to make sure, they work again next time.
+
+*/
+Template['AnimateWithVelocity'].destroyed = function(){
+    var template = this;
+    Meteor.defer(function(){
+        template._animation_helper_parentNode._uihooks = null;
+    });
+};
 
 
 // METHODS

--- a/animation-helper-velocity.js
+++ b/animation-helper-velocity.js
@@ -32,9 +32,6 @@ Template['AnimateWithVelocity'].rendered = function(){
         }
     });
 
-    // add the parentNode te the instance, so we can access it in the destroyed function
-    this._animation_helper_parentNode = this.firstNode.parentNode;
-
     this._animation_helper_parentNode._uihooks = {
         insertElement: function (node, next) {
 


### PR DESCRIPTION
I've added data-animate-on-render option to disable animation on render. It could be useful inside #each loops where you don't want to animate the render, just when a new element is inserted or removed.
